### PR TITLE
Modify for TF versions > 1.0

### DIFF
--- a/ignition/ignition.tf
+++ b/ignition/ignition.tf
@@ -1,3 +1,13 @@
+// ignition moved from a builtin to a community provider
+terraform {
+  required_providers {
+    ignition = {
+      source  = "community-terraform-providers/ignition"
+      version = "2.1.2"
+    }
+  }
+}
+
 locals {
   installer_workspace     = "${path.root}/installer-files"
   openshift_installer_url = "${var.openshift_installer_url}/${var.openshift_version}"

--- a/ignition/ignition.tf
+++ b/ignition/ignition.tf
@@ -36,10 +36,11 @@ fi
 EOF
   }
 
-  provisioner "local-exec" {
-    when    = destroy
-    command = "rm -rf ${local.installer_workspace}"
-  }
+  //  This no longer works with newer versions of TF
+  //  provisioner "local-exec" {
+  //    when    = destroy
+  //    command = "rm -rf ${local.installer_workspace}"
+  //  }
 
 }
 

--- a/main.tf
+++ b/main.tf
@@ -2,9 +2,6 @@ provider "google" {
   credentials = file(var.gcp_service_account)
   project     = var.gcp_project_id
   region      = var.gcp_region
-  version     = "=2.20.1"
-  # pinning to version 2.20.1 until this issue is resolved
-  # https://github.com/terraform-providers/terraform-provider-google/issues/5107
 }
 
 resource "random_string" "cluster_id" {


### PR DESCRIPTION
1) We no longer need to pin the google provider version as the documented fix is now closed

2) We no longer remove the workspace as when destroys are no longer honored

3) ignition has moved from a built-in provider to a community provider and we now have to pull it in accordingly